### PR TITLE
Add pinata-ssh-env command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,5 +13,6 @@ install:
 	cp ssh-find-agent.sh $(PREFIX)/share/pinata-ssh-agent/ssh-find-agent.sh
 	@mkdir -p $(BINDIR)
 	cp pinata-build-sshd.sh $(BINDIR)/pinata-build-sshd
+	cp pinata-ssh-env.sh $(BINDIR)/pinata-ssh-env
 	cp pinata-ssh-forward.sh $(BINDIR)/pinata-ssh-forward
 	cp pinata-ssh-mount.sh $(BINDIR)/pinata-ssh-mount

--- a/pinata-ssh-env.sh
+++ b/pinata-ssh-env.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+LOCAL_STATE=~/.pinata-sshd
+AGENT=`cat ${LOCAL_STATE}/agent_socket_path | sed -e 's,/tmp/,,g'`
+
+echo "Run this command to configure your shell:\neval \$(pinata-ssh-env)" >&2
+echo "export PINATA_LOCAL_AGENT=$LOCAL_STATE/$AGENT"
+echo "export PINATA_SSH_AUTH_SOCK=/tmp/ssh-agent.sock"

--- a/pinata-ssh-mount.sh
+++ b/pinata-ssh-mount.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 
-LOCAL_STATE=~/.pinata-sshd
-AGENT=`cat ${LOCAL_STATE}/agent_socket_path | sed -e 's,/tmp/,,g'`
-echo "-v ${LOCAL_STATE}/$AGENT:/tmp/ssh-agent.sock --env SSH_AUTH_SOCK=/tmp/ssh-agent.sock"
+eval $(pinata-ssh-env 2>/dev/null)
+echo "-v $PINATA_LOCAL_AGENT:$PINATA_SSH_AUTH_SOCK --env SSH_AUTH_SOCK=$PINATA_SSH_AUTH_SOCK"


### PR DESCRIPTION
It can be useful to get the environment variables themselves for
constructing our own commands, rather than concatenating the output of
`pinata-ssh-mount`. This adds a command to do that (similar to
docker-machine's env command)
