### PR TITLE
Socat-based approach

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM alpine
 MAINTAINER Anil Madhavapeddy <anil@recoil.org>
 RUN apk update && apk add openssh socat
 RUN mkdir /root/.ssh && \
-    chmod 700 /root/.ssh && \
-    ssh-keygen -A
+    chmod 700 /root/.ssh
 COPY ssh-forward-agent.sh /root/ssh-forward-agent.sh
 COPY docker-entrypoint.sh /
 EXPOSE 22

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM alpine
 MAINTAINER Anil Madhavapeddy <anil@recoil.org>
-RUN apk update && apk add openssh && \
-    apk add --update --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ tini
+RUN apk update && apk add openssh socat
 RUN mkdir /root/.ssh && \
     chmod 700 /root/.ssh && \
     ssh-keygen -A
-COPY ssh-find-agent.sh /root/ssh-find-agent.sh
+COPY ssh-forward-agent.sh /root/ssh-forward-agent.sh
+COPY docker-entrypoint.sh /
 EXPOSE 22
-VOLUME ["/root/.ssh/authorized_keys"]
-ENTRYPOINT ["/usr/bin/tini","--"]
+VOLUME ["/ssh-agent"]
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["/usr/sbin/sshd","-D"]

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ install:
 	@mkdir -p $(PREFIX)/share/pinata-ssh-agent
 	cp Dockerfile $(PREFIX)/share/pinata-ssh-agent
 	cp ssh-build.sh $(PREFIX)/share/pinata-ssh-agent/ssh-build
-	cp ssh-find-agent.sh $(PREFIX)/share/pinata-ssh-agent/ssh-find-agent.sh
+	cp ssh-forward-agent.sh $(PREFIX)/share/pinata-ssh-agent/ssh-forward-agent.sh
 	@mkdir -p $(BINDIR)
 	cp pinata-build-sshd.sh $(BINDIR)/pinata-build-sshd
 	cp pinata-ssh-forward.sh $(BINDIR)/pinata-ssh-forward

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+cp /tmp/.pinata-sshd/authorized_keys /root/.ssh/authorized_keys
+chown root:root /root/.ssh/authorized_keys
+exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 set -e
+
 echo $AUTHORIZED_KEYS | base64 -d >/root/.ssh/authorized_keys
 chown root:root /root/.ssh/authorized_keys
+
+ssh-keygen -A
+
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 set -e
-cp /tmp/.pinata-sshd/authorized_keys /root/.ssh/authorized_keys
+echo $AUTHORIZED_KEYS | base64 -d >/root/.ssh/authorized_keys
 chown root:root /root/.ssh/authorized_keys
 exec "$@"

--- a/pinata-build-sshd.sh
+++ b/pinata-build-sshd.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-cd /usr/local/share/pinata-ssh-agent
 docker build -t pinata-sshd .

--- a/pinata-ssh-forward.sh
+++ b/pinata-ssh-forward.sh
@@ -6,7 +6,7 @@ CONTAINER_NAME=pinata-sshd
 VOLUME_NAME=ssh-agent
 HOST_PORT=2244
 AUTHORIZED_KEYS=$(ssh-add -L | base64 | tr -d '\n')
-KNOWN_HOSTS_FILE=$(mktemp)
+KNOWN_HOSTS_FILE=$(mktemp -t dsaf.XXX)
 
 trap "rm ${KNOWN_HOSTS_FILE}" EXIT
 

--- a/pinata-ssh-forward.sh
+++ b/pinata-ssh-forward.sh
@@ -12,7 +12,7 @@ trap "rm ${KNOWN_HOSTS_FILE}" EXIT
 
 docker rm -f ${CONTAINER_NAME} >/dev/null 2>&1 || true
 
-docker volume create ${VOLUME_NAME}
+docker volume create --name ${VOLUME_NAME}
 
 docker run --name ${CONTAINER_NAME} \
   -e AUTHORIZED_KEYS="${AUTHORIZED_KEYS}" \

--- a/pinata-ssh-forward.sh
+++ b/pinata-ssh-forward.sh
@@ -5,15 +5,14 @@ IMAGE_NAME=pinata-sshd
 CONTAINER_NAME=pinata-sshd
 LOCAL_STATE=~/.pinata-sshd
 LOCAL_PORT=2244
+AUTHORIZED_KEYS=$(ssh-add -L | base64 -w0)
 
 docker rm -f ${CONTAINER_NAME} >/dev/null 2>&1 || true
 rm -rf ${LOCAL_STATE}
 mkdir -p ${LOCAL_STATE}
 
-ssh-add -L >${LOCAL_STATE}/authorized_keys
-
 docker run --name ${CONTAINER_NAME} \
-  -v ${LOCAL_STATE}:/tmp/.pinata-sshd \
+  -e AUTHORIZED_KEYS="${AUTHORIZED_KEYS}" \
   -d -p ${LOCAL_PORT}:22 ${IMAGE_NAME} > /dev/null
 
 if [ "${DOCKER_HOST}" ]; then

--- a/pinata-ssh-forward.sh
+++ b/pinata-ssh-forward.sh
@@ -3,6 +3,7 @@ set -e
 
 IMAGE_NAME=pinata-sshd
 CONTAINER_NAME=pinata-sshd
+VOLUME_NAME=ssh-agent
 HOST_PORT=2244
 AUTHORIZED_KEYS=$(ssh-add -L | base64 -w0)
 KNOWN_HOSTS_FILE=$(mktemp)
@@ -11,8 +12,11 @@ trap "rm ${KNOWN_HOSTS_FILE}" EXIT
 
 docker rm -f ${CONTAINER_NAME} >/dev/null 2>&1 || true
 
+docker volume create ${VOLUME_NAME}
+
 docker run --name ${CONTAINER_NAME} \
   -e AUTHORIZED_KEYS="${AUTHORIZED_KEYS}" \
+  -v ${VOLUME_NAME}:/ssh-agent \
   -d -p ${HOST_PORT}:22 ${IMAGE_NAME} > /dev/null
 
 if [ "${DOCKER_HOST}" ]; then

--- a/pinata-ssh-forward.sh
+++ b/pinata-ssh-forward.sh
@@ -3,7 +3,7 @@ set -e
 
 IMAGE_NAME=pinata-sshd
 CONTAINER_NAME=pinata-sshd
-LOCAL_PORT=2244
+HOST_PORT=2244
 AUTHORIZED_KEYS=$(ssh-add -L | base64 -w0)
 KNOWN_HOSTS_FILE=$(mktemp)
 
@@ -13,17 +13,17 @@ docker rm -f ${CONTAINER_NAME} >/dev/null 2>&1 || true
 
 docker run --name ${CONTAINER_NAME} \
   -e AUTHORIZED_KEYS="${AUTHORIZED_KEYS}" \
-  -d -p ${LOCAL_PORT}:22 ${IMAGE_NAME} > /dev/null
+  -d -p ${HOST_PORT}:22 ${IMAGE_NAME} > /dev/null
 
 if [ "${DOCKER_HOST}" ]; then
-  IP=$(echo $DOCKER_HOST | awk -F '//' '{print $2}' | awk -F ':' '{print $1}')
+  HOST_IP=$(echo $DOCKER_HOST | awk -F '//' '{print $2}' | awk -F ':' '{print $1}')
 else
-  IP=127.0.0.1
+  HOST_IP=127.0.0.1
 fi
-ssh-keyscan -p ${LOCAL_PORT} ${IP} > ${KNOWN_HOSTS_FILE} 2>/dev/null
+ssh-keyscan -p ${HOST_PORT} ${HOST_IP} > ${KNOWN_HOSTS_FILE} 2>/dev/null
 
 ssh -f -o "UserKnownHostsFile=${KNOWN_HOSTS_FILE}" \
-  -A -p ${LOCAL_PORT} root@${IP} \
+  -A -p ${HOST_PORT} root@${HOST_IP} \
   /root/ssh-forward-agent.sh
 
 echo 'Agent forwarding successfully started.'

--- a/pinata-ssh-forward.sh
+++ b/pinata-ssh-forward.sh
@@ -5,7 +5,7 @@ IMAGE_NAME=pinata-sshd
 CONTAINER_NAME=pinata-sshd
 VOLUME_NAME=ssh-agent
 HOST_PORT=2244
-AUTHORIZED_KEYS=$(ssh-add -L | base64 -w0)
+AUTHORIZED_KEYS=$(ssh-add -L | base64 | tr -d '\n')
 KNOWN_HOSTS_FILE=$(mktemp)
 
 trap "rm ${KNOWN_HOSTS_FILE}" EXIT

--- a/pinata-ssh-forward.sh
+++ b/pinata-ssh-forward.sh
@@ -3,13 +3,13 @@ set -e
 
 IMAGE_NAME=pinata-sshd
 CONTAINER_NAME=pinata-sshd
-LOCAL_STATE=~/.pinata-sshd
 LOCAL_PORT=2244
 AUTHORIZED_KEYS=$(ssh-add -L | base64 -w0)
+KNOWN_HOSTS_FILE=$(mktemp)
+
+trap "rm ${KNOWN_HOSTS_FILE}" EXIT
 
 docker rm -f ${CONTAINER_NAME} >/dev/null 2>&1 || true
-rm -rf ${LOCAL_STATE}
-mkdir -p ${LOCAL_STATE}
 
 docker run --name ${CONTAINER_NAME} \
   -e AUTHORIZED_KEYS="${AUTHORIZED_KEYS}" \
@@ -20,9 +20,9 @@ if [ "${DOCKER_HOST}" ]; then
 else
   IP=127.0.0.1
 fi
-ssh-keyscan -p ${LOCAL_PORT} ${IP} > ${LOCAL_STATE}/known_hosts 2>/dev/null
+ssh-keyscan -p ${LOCAL_PORT} ${IP} > ${KNOWN_HOSTS_FILE} 2>/dev/null
 
-ssh -f -o "UserKnownHostsFile=${LOCAL_STATE}/known_hosts" \
+ssh -f -o "UserKnownHostsFile=${KNOWN_HOSTS_FILE}" \
   -A -p ${LOCAL_PORT} root@${IP} \
   /root/ssh-forward-agent.sh
 

--- a/pinata-ssh-forward.sh
+++ b/pinata-ssh-forward.sh
@@ -24,6 +24,11 @@ if [ "${DOCKER_HOST}" ]; then
 else
   HOST_IP=127.0.0.1
 fi
+
+# FIXME Find a way to get rid of this additional 1s wait
+sleep 1
+while [ 1 ] && ! nc -z -w5 ${HOST_IP} ${HOST_PORT}; do sleep 0.1; done
+
 ssh-keyscan -p ${HOST_PORT} ${HOST_IP} > ${KNOWN_HOSTS_FILE} 2>/dev/null
 
 ssh -f -o "UserKnownHostsFile=${KNOWN_HOSTS_FILE}" \

--- a/pinata-ssh-mount.sh
+++ b/pinata-ssh-mount.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-echo "--volumes-from=pinata-sshd"
+echo "--volume=ssh-agent:/ssh-agent"
 echo "--env=SSH_AUTH_SOCK=/ssh-agent/ssh-agent.sock"

--- a/pinata-ssh-mount.sh
+++ b/pinata-ssh-mount.sh
@@ -1,5 +1,3 @@
 #!/bin/sh
 
-LOCAL_STATE=~/.pinata-sshd
-AGENT=`cat ${LOCAL_STATE}/agent_socket_path | sed -e 's,/tmp/,,g'`
-echo "-v ${LOCAL_STATE}/$AGENT:/tmp/ssh-agent.sock --env SSH_AUTH_SOCK=/tmp/ssh-agent.sock"
+echo "--volumes-from pinata-sshd --env SSH_AUTH_SOCK=/ssh-agent/ssh-agent.sock"

--- a/pinata-ssh-mount.sh
+++ b/pinata-ssh-mount.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 
-echo "--volumes-from pinata-sshd --env SSH_AUTH_SOCK=/ssh-agent/ssh-agent.sock"
+echo "--volumes-from=pinata-sshd"
+echo "--env=SSH_AUTH_SOCK=/ssh-agent/ssh-agent.sock"

--- a/ssh-find-agent.sh
+++ b/ssh-find-agent.sh
@@ -1,9 +1,0 @@
-#!/bin/sh -e
-# Log the location of the SSH agent to a file
-
-finish() {
- rm -f /tmp/agent_socket_path
-}
-trap finish EXIT
-echo $SSH_AUTH_SOCK > /tmp/agent_socket_path
-tail -f /dev/null

--- a/ssh-forward-agent.sh
+++ b/ssh-forward-agent.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -e
+# Forward SSH agent socket to a well-known location
+
+socat UNIX-LISTEN:/ssh-agent/ssh-agent.sock,fork UNIX-CONNECT:$SSH_AUTH_SOCK

--- a/ssh-forward-agent.sh
+++ b/ssh-forward-agent.sh
@@ -1,5 +1,6 @@
 #!/bin/sh -e
 # Forward SSH agent socket to a well-known location
+FORWARDED_SOCKET=/ssh-agent/ssh-agent.sock
 
-socat UNIX-LISTEN:/ssh-agent/ssh-agent.sock,fork UNIX-CONNECT:$SSH_AUTH_SOCK
-chmod 777 /ssh-agent/ssh-agent.sock
+rm -f ${FORWARDED_SOCKET}
+socat UNIX-LISTEN:${FORWARDED_SOCKET},fork,mode=777 UNIX-CONNECT:${SSH_AUTH_SOCK}

--- a/ssh-forward-agent.sh
+++ b/ssh-forward-agent.sh
@@ -2,3 +2,4 @@
 # Forward SSH agent socket to a well-known location
 
 socat UNIX-LISTEN:/ssh-agent/ssh-agent.sock,fork UNIX-CONNECT:$SSH_AUTH_SOCK
+chmod 777 /ssh-agent/ssh-agent.sock


### PR DESCRIPTION
@avsm Thanks for the great idea you had here! 

I changed this so it doesn't need local volumes anymore. This makes it work with boot2docker on Linux as well. Even more, it works with any remote docker host as long as the `DOCKER_` variables are set up correctly.

Also, it forwards _all_ keys available in the local agent. 

Last but not least, it uses a named volume so it can be used with Docker Compose V3 syntax. See [this example](https://gist.github.com/djmaze/8c3855ebca9f84cc9696e410e6b314bf).

For me, this is now close to a perfect solution for SSH agent forwarding. 

*EDIT:* Sorry for the bad PR name, I was unable to come up with a good one. Also, this could probably be split into multiple PRs. But for me this really is useful as a whole only.

![docker-ssh-agent-forward](https://cloud.githubusercontent.com/assets/7229/22775731/2f44fb20-eead-11e6-8297-eb5694de9a82.png)
