### PR TITLE
Fix error missing tini; use sbin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ RUN mkdir /root/.ssh && \
 COPY ssh-find-agent.sh /root/ssh-find-agent.sh
 EXPOSE 22
 VOLUME ["/root/.ssh/authorized_keys"]
-ENTRYPOINT ["/usr/bin/tini","--"]
+ENTRYPOINT ["/sbin/tini","--"]
 CMD ["/usr/sbin/sshd","-D"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
-all:
+all: install
 	./pinata-build-sshd.sh
-	@echo Please run "make install"
 
 PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Assuming you have a `/usr/local`
 ```
 $ git clone git://github.com/avsm/docker-ssh-agent-forward
 $ make
-$ make install
 ```
 
 On every boot, do:

--- a/pinata-ssh-forward.sh
+++ b/pinata-ssh-forward.sh
@@ -10,6 +10,7 @@ rm -rf ${LOCAL_STATE}
 mkdir -p ${LOCAL_STATE}
 
 docker run --name ${CONTAINER_NAME} \
+  --restart always \
   -v ~/.ssh/id_rsa.pub:/root/.ssh/authorized_keys \
   -v ${LOCAL_STATE}:/tmp \
   -d -p ${LOCAL_PORT}:22 ${IMAGE_NAME} > /dev/null


### PR DESCRIPTION
This PR fixes a bug running `tini` in the current Dockerfile. Perhaps this is a recent change, but the `tini` binary installs to `/sbin`, not `/usr/bin`, so `pinata-ssh-forward` fails.