### PR TITLE
Don't ssh as root, improve script robustness

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ RUN mkdir /root/.ssh && \
 COPY ssh-find-agent.sh /root/ssh-find-agent.sh
 EXPOSE 22
 VOLUME ["/root/.ssh/authorized_keys"]
-ENTRYPOINT ["/usr/bin/tini","--"]
+ENTRYPOINT ["/sbin/tini","--"]
 CMD ["/usr/sbin/sshd","-D"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,16 @@ FROM alpine
 MAINTAINER Anil Madhavapeddy <anil@recoil.org>
 RUN apk update && apk add openssh && \
     apk add --update --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ tini
-RUN mkdir /root/.ssh && \
-    chmod 700 /root/.ssh && \
-    ssh-keygen -A
-COPY ssh-find-agent.sh /root/ssh-find-agent.sh
+# Create a group and user
+RUN addgroup pinata && \
+    adduser -D pinata -G pinata -s /bin/sh && \
+    passwd -u pinata && \
+    mkdir /home/pinata/.ssh && \
+    chmod 700 /home/pinata/.ssh && \
+    chown pinata:pinata /home/pinata/.ssh && \
+    ssh-keygen -A 
+COPY ssh-find-agent.sh /home/pinata/ssh-find-agent.sh
 EXPOSE 22
-VOLUME ["/root/.ssh/authorized_keys"]
+VOLUME ["/home/pinata/.ssh/authorized_keys"]
 ENTRYPOINT ["/sbin/tini","--"]
-CMD ["/usr/sbin/sshd","-D"]
+CMD ["/usr/sbin/sshd", "-D"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
-all:
+all: install
 	./pinata-build-sshd.sh
-	@echo Please run "make install"
 
 PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,6 @@ install:
 	cp pinata-build-sshd.sh $(BINDIR)/pinata-build-sshd
 	cp pinata-ssh-forward.sh $(BINDIR)/pinata-ssh-forward
 	cp pinata-ssh-mount.sh $(BINDIR)/pinata-ssh-mount
+
+clean:
+	docker stop pinata-sshd; docker rm pinata-sshd; docker rmi pinata-sshd; true

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Assuming you have a `/usr/local`
 ```
 $ git clone git://github.com/avsm/docker-ssh-agent-forward
 $ make
-$ make install
 ```
 
 On every boot, do:

--- a/pinata-build-sshd.sh
+++ b/pinata-build-sshd.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
+set -e
 cd /usr/local/share/pinata-ssh-agent
 docker build -t pinata-sshd .

--- a/pinata-ssh-forward.sh
+++ b/pinata-ssh-forward.sh
@@ -11,7 +11,7 @@ mkdir -p ${LOCAL_STATE}
 
 docker run --name ${CONTAINER_NAME} \
   --restart always \
-  -v ~/.ssh/id_rsa.pub:/root/.ssh/authorized_keys \
+  -v ~/.ssh/id_rsa.pub:/home/pinata/.ssh/authorized_keys \
   -v ${LOCAL_STATE}:/tmp \
   -d -p ${LOCAL_PORT}:22 ${IMAGE_NAME} > /dev/null
 
@@ -19,8 +19,8 @@ IP=`docker inspect --format '{{(index (index .NetworkSettings.Ports "22/tcp") 0)
 ssh-keyscan -p ${LOCAL_PORT} ${IP} > ${LOCAL_STATE}/known_hosts 2>/dev/null
 
 ssh -f -o "UserKnownHostsFile=${LOCAL_STATE}/known_hosts" \
-  -A -p ${LOCAL_PORT} root@${IP} \
-  /root/ssh-find-agent.sh
+  -A -p ${LOCAL_PORT} pinata@${IP} \
+  '~/ssh-find-agent.sh'
 
 echo 'Agent forwarding successfully started.'
 echo 'Run "pinata-ssh-mount" to get a command-line fragment that'

--- a/pinata-ssh-forward.sh
+++ b/pinata-ssh-forward.sh
@@ -1,30 +1,84 @@
-#!/bin/sh -e
+#!/bin/sh
 
 IMAGE_NAME=pinata-sshd
 CONTAINER_NAME=pinata-sshd
 LOCAL_STATE=~/.pinata-sshd
 LOCAL_PORT=2244
 
-docker rm -f ${CONTAINER_NAME} >/dev/null 2>&1 || true
-rm -rf ${LOCAL_STATE}
-mkdir -p ${LOCAL_STATE}
+function check_running() {
+    test ! -z $(docker ps -f name=${CONTAINER_NAME} -q)
+}
 
-docker run --name ${CONTAINER_NAME} \
-  --restart always \
-  -v ~/.ssh/id_rsa.pub:/home/pinata/.ssh/authorized_keys \
-  -v ${LOCAL_STATE}:/tmp \
-  -d -p ${LOCAL_PORT}:22 ${IMAGE_NAME} > /dev/null
+function do_cleanup() {
+    set -e
+    docker rm -f ${CONTAINER_NAME} >/dev/null 2>&1 || true
+    rm -rf ${LOCAL_STATE}
+    mkdir -p ${LOCAL_STATE}
+}
 
-IP=`docker inspect --format '{{(index (index .NetworkSettings.Ports "22/tcp") 0).HostIp }}' ${CONTAINER_NAME}`
-ssh-keyscan -p ${LOCAL_PORT} ${IP} > ${LOCAL_STATE}/known_hosts 2>/dev/null
+function do_forward() {
+    set -e
+    docker run --name ${CONTAINER_NAME} \
+      --restart always \
+      -v ~/.ssh/id_rsa.pub:/home/pinata/.ssh/authorized_keys \
+      -v ${LOCAL_STATE}:/tmp \
+      -d -p ${LOCAL_PORT}:22 ${IMAGE_NAME} > /dev/null
+    
+    IP=`docker inspect --format '{{(index (index .NetworkSettings.Ports "22/tcp") 0).HostIp }}' ${CONTAINER_NAME}`
+    ssh-keyscan -p ${LOCAL_PORT} ${IP} > ${LOCAL_STATE}/known_hosts 2>/dev/null
+    
+    ssh -f -o "UserKnownHostsFile=${LOCAL_STATE}/known_hosts" \
+      -A -p ${LOCAL_PORT} pinata@${IP} \
+      '~/ssh-find-agent.sh'
+    
+    echo 'Agent forwarding successfully started.'
+    echo 'Run "pinata-ssh-mount" to get a command-line fragment that'
+    echo 'can be added to "docker run" to mount the SSH agent socket.'
+    echo ""
+    echo 'For example:'
+    echo 'docker run -it `pinata-ssh-mount` pinata-sshd ssh git@github.com'
+}
 
-ssh -f -o "UserKnownHostsFile=${LOCAL_STATE}/known_hosts" \
-  -A -p ${LOCAL_PORT} pinata@${IP} \
-  '~/ssh-find-agent.sh'
+function do_help() {
+    echo ""
+    echo "$(basename $0) [options]"
+    echo ""
+    echo "Options:"
+    echo "  -f     Force kill running ${CONTAINER_NAME} if it is running"
+    echo "  -h     Show this help and exit"
+    echo ""
+}
 
-echo 'Agent forwarding successfully started.'
-echo 'Run "pinata-ssh-mount" to get a command-line fragment that'
-echo 'can be added to "docker run" to mount the SSH agent socket.'
-echo ""
-echo 'For example:'
-echo 'docker run -it `pinata-ssh-mount` pinata-sshd ssh git@github.com'
+
+args=`getopt hf $*`
+if [ $? != 0 ]
+then
+   do_help
+   exit 2
+fi
+set -- $args
+opt_force=no
+for i
+do
+   case "$i"
+   in
+	   f)
+                   opt_force=yes
+		   shift;;
+	   -h)
+		   do_help; exit;
+		   shift;;
+	   --)
+		   shift; break;;
+   esac
+done
+
+if [ $opt_force == yes ]; then
+    do_cleanup
+fi
+
+if check_running; then
+    echo "${CONTAINER_NAME} is already running"
+else
+    do_forward
+fi

--- a/pinata-ssh-forward.sh
+++ b/pinata-ssh-forward.sh
@@ -10,6 +10,7 @@ rm -rf ${LOCAL_STATE}
 mkdir -p ${LOCAL_STATE}
 
 docker run --name ${CONTAINER_NAME} \
+  --restart always \
   -v ~/.ssh/id_rsa.pub:/root/.ssh/authorized_keys \
   -v ${LOCAL_STATE}:/tmp \
   -d -p ${LOCAL_PORT}:22 ${IMAGE_NAME} > /dev/null

--- a/pinata-ssh-forward.sh
+++ b/pinata-ssh-forward.sh
@@ -27,4 +27,4 @@ echo 'Run "pinata-ssh-mount" to get a command-line fragment that'
 echo 'can be added to "docker run" to mount the SSH agent socket.'
 echo ""
 echo 'For example:'
-echo 'docker run -it `pinata-ssh-mount` ocaml/opam ssh git@github.com'
+echo 'docker run -it `pinata-ssh-mount` pinata-sshd ssh git@github.com'


### PR DESCRIPTION
I couldn't quite convince sshd to allow root, so I moved all the processing to a separate user `pinata`
Improved robustness of the `pinata-ssh-forward` script, so that it restarts the container only if necessary.
