### PR TITLE
use PREFIX env var but default to /usr/local if not set

### DIFF
--- a/pinata-build-sshd.sh
+++ b/pinata-build-sshd.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-cd /usr/local/share/pinata-ssh-agent
+cd ${PREFIX:-/usr/local}/share/pinata-ssh-agent
 docker build -t pinata-sshd .


### PR DESCRIPTION
This simple fix seems to work for https://github.com/avsm/docker-ssh-agent-forward/issues/20